### PR TITLE
Extract common functions to independent package

### DIFF
--- a/pkg/deployment/diagnose.go
+++ b/pkg/deployment/diagnose.go
@@ -1,12 +1,9 @@
 package deployment
 
 import (
-	"bufio"
-	"bytes"
 	"context"
 	"errors"
 	"fmt"
-	"strings"
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -14,10 +11,10 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/kubernetes/scheme"
 
+	"github.com/Ladicle/kubectl-diagnose/pkg/pod"
 	"github.com/Ladicle/kubectl-diagnose/pkg/pritty"
-	"github.com/Ladicle/kubectl-diagnose/pkg/util/formatter"
+	condutil "github.com/Ladicle/kubectl-diagnose/pkg/util/cond"
 )
 
 // NewDiagnoser creates Deployment Diagnoser resource.
@@ -57,85 +54,21 @@ func (d *Diagnoser) Diagnose(printer *pritty.Printer) error {
 	if err != nil {
 		return err
 	}
-	for i := range pods.Items {
-		pod := &pods.Items[i]
-		if err := d.reportPodDetail(printer, pod); err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
-func isStatusTrue(status corev1.ConditionStatus) bool {
-	return status == corev1.ConditionTrue
-}
-
-// isContainerStarted is a function to checks if the current or the last container holds the ContainerID.
-// In other words, it is determined whether the container has been started even once.
-func isContainerStarted(cs corev1.ContainerStatus) bool {
-	switch {
-	case cs.Ready && cs.ContainerID != "":
-		return true
-	case cs.State.Terminated != nil && cs.State.Terminated.ContainerID != "":
-		return true
-	case cs.LastTerminationState.Terminated != nil && cs.LastTerminationState.Terminated.ContainerID != "":
-		return true
-	}
-	return false
-}
-
-func filterNotReadyContainers(css []corev1.ContainerStatus) []corev1.ContainerStatus {
-	var notReadyContainers []corev1.ContainerStatus
-	for _, cs := range css {
-		if !cs.Ready {
-			notReadyContainers = append(notReadyContainers, cs)
-		}
-	}
-	return notReadyContainers
-}
-
-func filterWarnEvents(events *corev1.EventList) []corev1.Event {
-	var warnEv []corev1.Event
-	for _, ev := range events.Items {
-		if ev.Type == corev1.EventTypeWarning {
-			warnEv = append(warnEv, ev)
-		}
-	}
-	return warnEv
-}
-
-func getContainerLog(c *kubernetes.Clientset, ns, pname, cname string) (string, error) {
-	var tailN = int64(15)
-	req := c.CoreV1().Pods(ns).GetLogs(pname, &corev1.PodLogOptions{
-		TailLines: &tailN,
-		Container: cname,
-	})
-
-	readCloser, err := req.Stream(context.TODO())
-	if err != nil {
-		return "", err
-	}
-	defer readCloser.Close()
-
-	var (
-		line int
-		buf  bytes.Buffer
-		r    = bufio.NewScanner(readCloser)
-	)
-	for r.Scan() {
-		buf.Write(r.Bytes())
-		buf.WriteString("\n")
-		line++
-	}
-	if line == 0 {
-		buf.WriteString("<none>\n")
-	}
-	return buf.String(), nil
+	return pod.ReportPodsDetail(d.Clientset, printer, pods.Items)
 }
 
 func getDeployment(c *kubernetes.Clientset, nn types.NamespacedName) (*appsv1.Deployment, error) {
 	return c.AppsV1().Deployments(nn.Namespace).Get(
 		context.Background(), nn.Name, metav1.GetOptions{})
+}
+
+func (d *Diagnoser) checkDeploymentAvailable(deploy *appsv1.Deployment) (bool, error) {
+	for _, cond := range deploy.Status.Conditions {
+		if cond.Type == appsv1.DeploymentAvailable {
+			return condutil.IsStatusTrue(cond.Status), nil
+		}
+	}
+	return false, nil
 }
 
 func getLatestPods(c *kubernetes.Clientset, deploy *appsv1.Deployment) (*corev1.PodList, error) {
@@ -167,75 +100,4 @@ func getLatestPods(c *kubernetes.Clientset, deploy *appsv1.Deployment) (*corev1.
 			tplhash),
 	}
 	return c.CoreV1().Pods(deploy.Namespace).List(context.Background(), opt)
-}
-
-func (d *Diagnoser) checkDeploymentAvailable(deploy *appsv1.Deployment) (bool, error) {
-	for _, cond := range deploy.Status.Conditions {
-		if cond.Type == appsv1.DeploymentAvailable {
-			return isStatusTrue(cond.Status), nil
-		}
-	}
-	return false, nil
-}
-
-func (d *Diagnoser) reportPodDetail(printer *pritty.Printer, pod *corev1.Pod) error {
-	readypp := make(map[string]bool, len(pod.Spec.ReadinessGates))
-	for _, rg := range pod.Spec.ReadinessGates {
-		readypp[string(rg.ConditionType)] = true
-	}
-
-	var (
-		errMsgList     []string
-		notReadyCSList []corev1.ContainerStatus
-	)
-	for _, cond := range pod.Status.Conditions {
-		var errMsg string
-		switch cond.Type {
-		case corev1.PodReady:
-			continue
-		case corev1.PodScheduled:
-			// noop
-		case corev1.PodInitialized:
-			notReadyCSList = filterNotReadyContainers(pod.Status.InitContainerStatuses)
-			errMsg = formatter.FormatContainerStatuses(pod.Name, notReadyCSList)
-		case corev1.ContainersReady:
-			notReadyCSList = filterNotReadyContainers(pod.Status.ContainerStatuses)
-			errMsg = formatter.FormatContainerStatuses(pod.Name, notReadyCSList)
-		}
-		if isStatusTrue(cond.Status) {
-			continue
-		}
-		if errMsg == "" {
-			errMsg = fmt.Sprintf("[%v] Pod/%v: %v", cond.Type, pod.Name, cond.Message)
-		}
-		errMsgList = append(errMsgList, errMsg)
-	}
-
-	events, err := d.CoreV1().Events(pod.Namespace).Search(scheme.Scheme, pod)
-	if err != nil {
-		return err
-	}
-	warnEventList := filterWarnEvents(events)
-
-	if len(errMsgList) != 0 {
-		fmt.Fprintf(printer.IOStreams.Out,
-			"%v\n", strings.Join(errMsgList, "\n"))
-
-		for _, cs := range notReadyCSList {
-			if !isContainerStarted(cs) {
-				continue
-			}
-			log, err := getContainerLog(d.Clientset, pod.Namespace, pod.Name, cs.Name)
-			if err != nil {
-				return err
-			}
-			fmt.Fprintf(printer.IOStreams.Out,
-				"\nContainer{%q} Log:\n%v\n", cs.Name, log)
-		}
-	}
-	if len(warnEventList) != 0 {
-		fmt.Fprintf(printer.IOStreams.Out,
-			"\n%v\n", formatter.FormatEvents(warnEventList))
-	}
-	return nil
 }

--- a/pkg/pod/container.go
+++ b/pkg/pod/container.go
@@ -1,0 +1,49 @@
+package pod
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/kubernetes"
+)
+
+func filterNotReadyContainers(css []corev1.ContainerStatus) []corev1.ContainerStatus {
+	var notReadyContainers []corev1.ContainerStatus
+	for _, cs := range css {
+		if !cs.Ready {
+			notReadyContainers = append(notReadyContainers, cs)
+		}
+	}
+	return notReadyContainers
+}
+
+func getContainerLog(c *kubernetes.Clientset, ns, pname, cname string) (string, error) {
+	var tailN = int64(15)
+	req := c.CoreV1().Pods(ns).GetLogs(pname, &corev1.PodLogOptions{
+		TailLines: &tailN,
+		Container: cname,
+	})
+
+	readCloser, err := req.Stream(context.TODO())
+	if err != nil {
+		return "", err
+	}
+	defer readCloser.Close()
+
+	var (
+		line int
+		buf  bytes.Buffer
+		r    = bufio.NewScanner(readCloser)
+	)
+	for r.Scan() {
+		buf.Write(r.Bytes())
+		buf.WriteString("\n")
+		line++
+	}
+	if line == 0 {
+		buf.WriteString("<none>\n")
+	}
+	return buf.String(), nil
+}

--- a/pkg/pod/diagnose.go
+++ b/pkg/pod/diagnose.go
@@ -1,0 +1,100 @@
+package pod
+
+import (
+	"fmt"
+	"strings"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/kubectl/pkg/scheme"
+
+	"github.com/Ladicle/kubectl-diagnose/pkg/pritty"
+	condutil "github.com/Ladicle/kubectl-diagnose/pkg/util/cond"
+	eventutil "github.com/Ladicle/kubectl-diagnose/pkg/util/event"
+	"github.com/Ladicle/kubectl-diagnose/pkg/util/formatter"
+)
+
+func ReportPodsDetail(c *kubernetes.Clientset, printer *pritty.Printer, pods []corev1.Pod) error {
+	for i := range pods {
+		if err := reportPodDetail(c, printer, &pods[i]); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func reportPodDetail(c *kubernetes.Clientset, printer *pritty.Printer, pod *corev1.Pod) error {
+	readypp := make(map[string]bool, len(pod.Spec.ReadinessGates))
+	for _, rg := range pod.Spec.ReadinessGates {
+		readypp[string(rg.ConditionType)] = true
+	}
+
+	var (
+		errMsgList     []string
+		notReadyCSList []corev1.ContainerStatus
+	)
+	for _, cond := range pod.Status.Conditions {
+		var errMsg string
+		switch cond.Type {
+		case corev1.PodReady:
+			continue
+		case corev1.PodScheduled:
+			// noop
+		case corev1.PodInitialized:
+			notReadyCSList = filterNotReadyContainers(pod.Status.InitContainerStatuses)
+			errMsg = formatter.FormatContainerStatuses(pod.Name, notReadyCSList)
+		case corev1.ContainersReady:
+			notReadyCSList = filterNotReadyContainers(pod.Status.ContainerStatuses)
+			errMsg = formatter.FormatContainerStatuses(pod.Name, notReadyCSList)
+		}
+		if condutil.IsStatusTrue(cond.Status) {
+			continue
+		}
+		if errMsg == "" {
+			errMsg = fmt.Sprintf("[%v] Pod/%v: %v", cond.Type, pod.Name, cond.Message)
+		}
+		errMsgList = append(errMsgList, errMsg)
+	}
+
+	events, err := c.CoreV1().Events(pod.Namespace).Search(scheme.Scheme, pod)
+	if err != nil {
+		return err
+	}
+	warnEventList := eventutil.FilterWarnEvents(events)
+
+	if len(errMsgList) != 0 {
+		fmt.Fprintf(printer.IOStreams.Out,
+			"%v\n", strings.Join(errMsgList, "\n"))
+
+		for _, cs := range notReadyCSList {
+			if !isContainerStarted(cs) {
+				continue
+			}
+			log, err := getContainerLog(c, pod.Namespace, pod.Name, cs.Name)
+			if err != nil {
+				return err
+			}
+			fmt.Fprintf(printer.IOStreams.Out,
+				"\nContainer{%q} Log:\n%v\n", cs.Name, log)
+		}
+	}
+	if len(warnEventList) != 0 {
+		fmt.Fprintf(printer.IOStreams.Out,
+			"\n%v\n", formatter.FormatEvents(warnEventList))
+	}
+	return nil
+}
+
+// isContainerStarted is a function to checks if the current or the last container holds the ContainerID.
+// In other words, it is determined whether the container has been started even once.
+func isContainerStarted(cs corev1.ContainerStatus) bool {
+	switch {
+	case cs.Ready && cs.ContainerID != "":
+		return true
+	case cs.State.Terminated != nil && cs.State.Terminated.ContainerID != "":
+		return true
+	case cs.LastTerminationState.Terminated != nil && cs.LastTerminationState.Terminated.ContainerID != "":
+		return true
+	}
+	return false
+}

--- a/pkg/util/cond/cond.go
+++ b/pkg/util/cond/cond.go
@@ -1,0 +1,7 @@
+package cond
+
+import corev1 "k8s.io/api/core/v1"
+
+func IsStatusTrue(status corev1.ConditionStatus) bool {
+	return status == corev1.ConditionTrue
+}

--- a/pkg/util/event/filter.go
+++ b/pkg/util/event/filter.go
@@ -1,0 +1,13 @@
+package event
+
+import corev1 "k8s.io/api/core/v1"
+
+func FilterWarnEvents(events *corev1.EventList) []corev1.Event {
+	var warnEv []corev1.Event
+	for _, ev := range events.Items {
+		if ev.Type == corev1.EventTypeWarning {
+			warnEv = append(warnEv, ev)
+		}
+	}
+	return warnEv
+}


### PR DESCRIPTION
This PR moves common functions into separate packages. The `deployment` package contained functions related to pod and containers before. However, these functions are used in other commands.