### PR TITLE
Add StatefulSet sub-command

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -43,6 +43,7 @@ func NewDiagnoseCmd() *cobra.Command {
 	printer.TTY = term.TTY{Out: ioStreams.Out}.IsTerminalOut()
 
 	cmds.AddCommand(NewDeploymentCmd(f, printer))
+	cmds.AddCommand(NewStatefulSetCmd(f, printer))
 
 	return cmds
 }

--- a/cmd/statefulset.go
+++ b/cmd/statefulset.go
@@ -1,0 +1,67 @@
+package cmd
+
+import (
+	"errors"
+
+	"github.com/spf13/cobra"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes"
+	cmdutil "k8s.io/kubectl/pkg/cmd/util"
+
+	"github.com/Ladicle/kubectl-diagnose/pkg/pritty"
+	"github.com/Ladicle/kubectl-diagnose/pkg/statefulset"
+	dcmdutil "github.com/Ladicle/kubectl-diagnose/pkg/util/cmd"
+)
+
+type StatefulSetOptions struct {
+	Name      string
+	Namespace string
+
+	clientset *kubernetes.Clientset
+}
+
+func NewStatefulSetCmd(f cmdutil.Factory, printer *pritty.Printer) *cobra.Command {
+	opts := StatefulSetOptions{}
+	cmd := &cobra.Command{
+		Use:                   "statefulset <name>",
+		Aliases:               []string{"sts"},
+		DisableFlagsInUseLine: true,
+		Short:                 "Diagnose StatefulSet resource",
+		Run: func(cmd *cobra.Command, args []string) {
+			dcmdutil.CheckErr(opts.Validate(args))
+			dcmdutil.CheckErr(opts.Complete(f))
+			dcmdutil.CheckErr(opts.Run(printer))
+		},
+	}
+	return cmd
+}
+
+func (o *StatefulSetOptions) Validate(args []string) error {
+	if len(args) != 1 {
+		return errors.New("invalid number of arguments: StatefulSet <name> is a required argument")
+	}
+	o.Name = args[0]
+	return nil
+}
+
+func (o *StatefulSetOptions) Complete(f cmdutil.Factory) error {
+	c, err := f.KubernetesClientSet()
+	if err != nil {
+		return err
+	}
+	o.clientset = c
+
+	k8sCfg := f.ToRawKubeConfigLoader()
+	ns, _, err := k8sCfg.Namespace()
+	if err != nil {
+		return err
+	}
+	o.Namespace = ns
+	return nil
+}
+
+func (o *StatefulSetOptions) Run(printer *pritty.Printer) error {
+	target := types.NamespacedName{Name: o.Name, Namespace: o.Namespace}
+	diagnoser := statefulset.NewDiagnoser(target, o.clientset)
+	return diagnoser.Diagnose(printer)
+}

--- a/pkg/statefulset/diagnose.go
+++ b/pkg/statefulset/diagnose.go
@@ -1,0 +1,68 @@
+package statefulset
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes"
+
+	"github.com/Ladicle/kubectl-diagnose/pkg/pod"
+	"github.com/Ladicle/kubectl-diagnose/pkg/pritty"
+)
+
+// NewDiagnoser creates Statefulset Diagnoser resource.
+func NewDiagnoser(target types.NamespacedName, clientset *kubernetes.Clientset) *Diagnoser {
+	d := &Diagnoser{
+		Target:    target,
+		Clientset: clientset,
+	}
+	return d
+}
+
+// Diagnoser diagnoses a target statefulset resource.
+type Diagnoser struct {
+	Target types.NamespacedName
+
+	*kubernetes.Clientset
+}
+
+func (d *Diagnoser) Diagnose(printer *pritty.Printer) error {
+	sts, err := getStatefulSet(d.Clientset, d.Target)
+	if err != nil {
+		return err
+	}
+
+	if sts.Status.ReadyReplicas == sts.Status.Replicas {
+		fmt.Fprintf(printer.IOStreams.Out, "%v is ready\n", d.Target)
+	}
+
+	fmt.Fprintf(printer.IOStreams.Out, "Deployment %q is not ready (%d/%d):\n\n",
+		d.Target, sts.Status.ReadyReplicas, sts.Status.Replicas)
+	pods, err := getChildPods(d.Clientset, sts)
+	if err != nil {
+		return err
+	}
+	return pod.ReportPodsDetail(d.Clientset, printer, pods.Items)
+}
+
+func getStatefulSet(c *kubernetes.Clientset, nn types.NamespacedName) (*appsv1.StatefulSet, error) {
+	return c.AppsV1().StatefulSets(nn.Namespace).
+		Get(context.Background(), nn.Name, metav1.GetOptions{})
+}
+
+func getChildPods(c *kubernetes.Clientset, sts *appsv1.StatefulSet) (*corev1.PodList, error) {
+	if sts.Status.CurrentRevision == "" {
+		return nil, errors.New(".state.currentRevision is empty")
+	}
+	opt := metav1.ListOptions{
+		LabelSelector: fmt.Sprintf("%v=%v",
+			appsv1.ControllerRevisionHashLabelKey,
+			sts.Status.CurrentRevision),
+	}
+	return c.CoreV1().Pods(sts.Namespace).List(context.Background(), opt)
+}


### PR DESCRIPTION
Support StatefulSet diagnostics. sts command checks the number of pods that has the specified statefulset as a parent, and if it does not have enough ready pods, the commands output the pod detail.