### PR TITLE
Add daemonset sub-command

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -44,6 +44,7 @@ func NewDiagnoseCmd() *cobra.Command {
 
 	cmds.AddCommand(NewDeploymentCmd(f, printer))
 	cmds.AddCommand(NewStatefulSetCmd(f, printer))
+	cmds.AddCommand(NewDaemonSetCmd(f, printer))
 
 	return cmds
 }

--- a/cmd/daemonset.go
+++ b/cmd/daemonset.go
@@ -1,0 +1,67 @@
+package cmd
+
+import (
+	"errors"
+
+	"github.com/spf13/cobra"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes"
+	cmdutil "k8s.io/kubectl/pkg/cmd/util"
+
+	"github.com/Ladicle/kubectl-diagnose/pkg/daemonset"
+	"github.com/Ladicle/kubectl-diagnose/pkg/pritty"
+	dcmdutil "github.com/Ladicle/kubectl-diagnose/pkg/util/cmd"
+)
+
+type DaemonSetOptions struct {
+	Name      string
+	Namespace string
+
+	clientset *kubernetes.Clientset
+}
+
+func NewDaemonSetCmd(f cmdutil.Factory, printer *pritty.Printer) *cobra.Command {
+	opts := DaemonSetOptions{}
+	cmd := &cobra.Command{
+		Use:                   "daemonset <name>",
+		Aliases:               []string{"ds"},
+		DisableFlagsInUseLine: true,
+		Short:                 "Diagnose DaemonSet resource",
+		Run: func(cmd *cobra.Command, args []string) {
+			dcmdutil.CheckErr(opts.Validate(args))
+			dcmdutil.CheckErr(opts.Complete(f))
+			dcmdutil.CheckErr(opts.Run(printer))
+		},
+	}
+	return cmd
+}
+
+func (o *DaemonSetOptions) Validate(args []string) error {
+	if len(args) != 1 {
+		return errors.New("invalid number of arguments: DaemonSet <name> is a required argument")
+	}
+	o.Name = args[0]
+	return nil
+}
+
+func (o *DaemonSetOptions) Complete(f cmdutil.Factory) error {
+	c, err := f.KubernetesClientSet()
+	if err != nil {
+		return err
+	}
+	o.clientset = c
+
+	k8sCfg := f.ToRawKubeConfigLoader()
+	ns, _, err := k8sCfg.Namespace()
+	if err != nil {
+		return err
+	}
+	o.Namespace = ns
+	return nil
+}
+
+func (o *DaemonSetOptions) Run(printer *pritty.Printer) error {
+	target := types.NamespacedName{Name: o.Name, Namespace: o.Namespace}
+	diagnoser := daemonset.NewDiagnoser(target, o.clientset)
+	return diagnoser.Diagnose(printer)
+}

--- a/pkg/daemonset/diagnose.go
+++ b/pkg/daemonset/diagnose.go
@@ -1,0 +1,76 @@
+package daemonset
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes"
+
+	"github.com/Ladicle/kubectl-diagnose/pkg/pod"
+	"github.com/Ladicle/kubectl-diagnose/pkg/pritty"
+)
+
+// NewDiagnoser creates Statefulset Diagnoser resource.
+func NewDiagnoser(target types.NamespacedName, clientset *kubernetes.Clientset) *Diagnoser {
+	d := &Diagnoser{
+		Target:    target,
+		Clientset: clientset,
+	}
+	return d
+}
+
+// Diagnoser diagnoses a target statefulset resource.
+type Diagnoser struct {
+	Target types.NamespacedName
+
+	*kubernetes.Clientset
+}
+
+func (d *Diagnoser) Diagnose(printer *pritty.Printer) error {
+	ds, err := getDaemonSet(d.Clientset, d.Target)
+	if err != nil {
+		return err
+	}
+
+	if ds.Status.NumberReady == ds.Status.DesiredNumberScheduled {
+		fmt.Fprintf(printer.IOStreams.Out, "%v is ready\n", d.Target)
+		return nil
+	}
+
+	fmt.Fprintf(printer.IOStreams.Out, "DaemonSet %q is not ready (%d/%d):\n\n",
+		d.Target, ds.Status.NumberReady, ds.Status.DesiredNumberScheduled)
+	pods, err := getChildPods(d.Clientset, ds)
+	if err != nil {
+		return err
+	}
+	return pod.ReportPodsDetail(d.Clientset, printer, pods.Items)
+}
+
+func getDaemonSet(c *kubernetes.Clientset, nn types.NamespacedName) (*appsv1.DaemonSet, error) {
+	return c.AppsV1().DaemonSets(nn.Namespace).
+		Get(context.Background(), nn.Name, metav1.GetOptions{})
+}
+
+func getChildPods(c *kubernetes.Clientset, ds *appsv1.DaemonSet) (*corev1.PodList, error) {
+	if ds.Status.ObservedGeneration == 0 {
+		return nil, errors.New(".state.observedGeneration is empty")
+	}
+
+	var labelSelector []string
+	for k, v := range ds.Spec.Selector.MatchLabels {
+		labelSelector = append(labelSelector, fmt.Sprintf("%v=%v", k, v))
+	}
+	opt := metav1.ListOptions{
+		LabelSelector: fmt.Sprintf("%v=%v,%v",
+			"pod-template-generation",
+			ds.Status.ObservedGeneration,
+			strings.Join(labelSelector, ",")),
+	}
+	return c.CoreV1().Pods(ds.Namespace).List(context.Background(), opt)
+}


### PR DESCRIPTION
Support DaemonSet diagnostics. ds command checks the number of pods that has the specified daemonset as a parent, and if it does not have enough ready pods, the commands output the pod detail.